### PR TITLE
Suppress NoActivePlayer logs as they aren't really an error

### DIFF
--- a/MediaController.py
+++ b/MediaController.py
@@ -63,7 +63,8 @@ class MediaController:
                     iface = dbus.Interface(player, 'org.mpris.MediaPlayer2.Player')
                     ifaces.append(iface)
             except dbus.exceptions.DBusException as e:
-                log.warning(e)
+                if e.get_dbus_name() != "com.github.altdesktop.playerctld.NoActivePlayer":
+                    log.warning(e)
         return ifaces
     
     def pause(self, player_name: str = None):


### PR DESCRIPTION
When the plugin starts up and the mpris server doesn't have an active player, the plugin will spam the logs with the exception. This change suppresses logs of NoActivePlayer exceptions, which aren't really an error. 