### PR TITLE
Use private non-GLib-integrated D-Bus connection to fix main-loop CPU spin

### DIFF
--- a/MediaController.py
+++ b/MediaController.py
@@ -1,6 +1,7 @@
 from functools import lru_cache
 from itertools import groupby
 import dbus
+import dbus.mainloop
 import sys
 import os
 import io
@@ -14,7 +15,14 @@ from loguru import logger as log
 
 class MediaController:
     def __init__(self):
-        self.session_bus = dbus.SessionBus()
+        # Use a private connection with no main-loop integration: the shared
+        # SessionBus singleton attaches its watch sources to the default GLib
+        # main context (StreamController sets DBusGMainLoop as default), and
+        # blocking calls from the tick thread then leave that source
+        # permanently ready, spinning the GTK main loop at 100% CPU.
+        # NULL_MAIN_LOOP keeps this connection self-polling; this plugin uses
+        # no D-Bus signal receivers, so no main loop is needed.
+        self.session_bus = dbus.SessionBus(private=True, mainloop=dbus.mainloop.NULL_MAIN_LOOP)
 
         self.update_players()
 


### PR DESCRIPTION
Fixes #32 — StreamController's GTK main thread spins at ~100% CPU whenever MediaPlugin is active.

### What

One functional line: `MediaController` now opens a **private** D-Bus connection with **no main-loop integration** (`mainloop=dbus.mainloop.NULL_MAIN_LOOP`) instead of the shared `dbus.SessionBus()` singleton.

### Why

StreamController core sets `DBusGMainLoop(set_as_default=True)`, so the shared session bus attaches its watch sources to the GTK main context. MediaController's MPRIS calls are all blocking calls from the `tick_actions` thread, which leaves the connection's GSource permanently "ready" while the tick thread owns the connection — the main loop wakes, dispatches nothing, and re-polls forever, pegging one core for the lifetime of the process. Full analysis with py-spy native profiles in the linked issue.

With a private non-integrated connection, blocking calls poll their own socket (thread-safe in libdbus) and never touch the GLib context.

### Safety

- The plugin registers no D-Bus signal receivers (`connect_to_signal` / `add_signal_receiver`), so nothing in this repo needs main-loop integration.
- `private=True` avoids mutating behavior of the shared singleton for core or other plugins.

### Tested

Live deployment on GNOME Wayland (Python 3.14, dbus-python 1.4.0, GLib 2.88): main-thread CPU drops from a sustained 99.9% to idle after this change; play/pause/next, metadata, album art, and player discovery verified working against Firefox and MPD.

Diagnosed and fixed with help from Claude (Fable 5) — attribution retained in the commit trailer.
