### PR TITLE
Fix album art for browser players: fetch file:// thumbnails that only exist on the host

### DIFF
--- a/MediaController.py
+++ b/MediaController.py
@@ -274,6 +274,7 @@ class MediaController:
                     thumbnails.append(None)
                     continue
                 path = path.replace("file://", "")
+                path = self.resolve_host_path(path)
                 thumbnails.append(path)
             except (KeyError, IndexError) as e:
                 thumbnails.append(None)
@@ -282,6 +283,47 @@ class MediaController:
                 thumbnails.append(None)            
 
         return self.compress_list(thumbnails)
+
+    def resolve_host_path(self, path: str) -> str:
+        """
+        Resolve a file:// thumbnail path that may only exist on the host.
+
+        Browser-based players (Chromium, Firefox) write their MPRIS art to the
+        host's /tmp, which is not visible inside the flatpak sandbox. If the
+        path does not exist in the sandbox, fetch the file via
+        `flatpak-spawn --host` and cache it under the plugin's cache directory,
+        keyed by content hash so a track change produces a new path (which the
+        thumbnail change detection relies on).
+
+        Args:
+            path (str): Absolute path from the player's mpris:artUrl.
+
+        Returns:
+            str: A readable path to the artwork, or the original path if it
+            could not be fetched.
+        """
+        if os.path.exists(path):
+            return path
+        import hashlib
+        import subprocess
+        try:
+            # cwd="/": flatpak-spawn --host starts the host command in the
+            # caller's cwd, and the sandbox cwd (/app/...) does not exist on the host
+            result = subprocess.run(["flatpak-spawn", "--host", "cat", path],
+                                    capture_output=True, timeout=5, cwd="/")
+            if result.returncode != 0 or not result.stdout:
+                log.debug(f"Could not fetch host thumbnail {path}: rc={result.returncode}")
+                return path
+            cache_dir = os.path.join(gl.DATA_PATH, "com_core447_MediaPlugin", "cache")
+            os.makedirs(cache_dir, exist_ok=True)
+            cached = os.path.join(cache_dir, hashlib.md5(result.stdout).hexdigest() + ".art")
+            if not os.path.exists(cached):
+                with open(cached, "wb") as f:
+                    f.write(result.stdout)
+            return cached
+        except Exception as e:
+            log.error(f"Failed to fetch host thumbnail {path}: {e}")
+            return path
 
     def compress_list(self, _list) -> list | bool:
         if len(_list) == 0:


### PR DESCRIPTION
## Problem

Browser-based players (Chromium/Chrome, and Firefox on some setups) expose `mpris:artUrl` as a `file://` path in the **host's** `/tmp` (e.g. `file:///tmp/.com.google.Chrome.XXXXXX`). That directory is not visible inside the flatpak sandbox, so `thumbnail()` returns a path that fails the `os.path.isfile` check in the actions and the album art silently never renders — while https art (Spotify etc.) works fine.

## Fix

When the resolved `file://` path does not exist in the sandbox, fetch the file via `flatpak-spawn --host cat` (the app manifest already grants `org.freedesktop.Flatpak` talk permission) and store it in the existing plugin cache dir (`gl.DATA_PATH/com_core447_MediaPlugin/cache`, which the plugin already clears on startup).

Two details worth noting:

- The cache file is keyed by **content hash**, not source path: Chromium reuses/rotates the same temp filenames between tracks, so a path-keyed cache would defeat the thumbnail change detection (`last_thumbnail_path`) and leave stale art on track changes.
- `flatpak-spawn` must run with `cwd="/"` — it starts the host command in the caller's working directory, and the sandbox cwd (`/app/bin/StreamController`) does not exist on the host, which otherwise fails with `Portal call failed: Failed to change to directory "/app/bin/StreamController"`.

Native paths that do exist in the sandbox are returned unchanged, and any failure falls back to the original path (current behavior).

## Tested

StreamController 1.5.0-beta.15 (flatpak) on Ubuntu (GNOME 50, Wayland), Stream Deck MK.2, with Chrome as the MPRIS player: Thumbnail Background (2x2 grid mode) went from permanently blank to rendering and following track changes. https-art players are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)